### PR TITLE
Complete user story 11. Create section for pending apps only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'faker'
-  # gem 'factorybot'
+  gem 'factory_bot'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     docile (1.4.0)
     erubi (1.12.0)
     execjs (2.8.1)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
@@ -243,6 +245,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)
+  factory_bot
   faker
   jbuilder (~> 2.5)
   launchy

--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -2,5 +2,6 @@ class Admin::SheltersController < ApplicationController
 
   def index
     @shelters = Shelter.order_by_name_reverse
+    @shelters_pending_apps = Shelter.joins(pets: [:pet_applicants])
   end
 end

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -6,4 +6,9 @@
 
 <section>
   <h2>Shelters with Pending Applications</h2>
+  <% @shelters_pending_apps.each do |shelter| %>
+  <div id="shelter-<%= shelter.id %>">
+  <p><%= shelter.name %></p>
+  <% end %>
+  </div>
 </section>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_31_051159) do
+ActiveRecord::Schema.define(version: 2023_04_03_012349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "applicants", force: :cascade do |t|
     t.string "name"
@@ -54,6 +59,8 @@ ActiveRecord::Schema.define(version: 2023_03_31_051159) do
     t.integer "rank"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "admin_id"
+    t.index ["admin_id"], name: "index_shelters_on_admin_id"
   end
 
   create_table "veterinarians", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,8 +26,9 @@ Applicant.delete_all
     @lasagna = @boulder.pets.create!(adoptable: true, age: 1, breed: 'orange tabby shorthair', name: 'Lasagna')
     
 ## APPLICANTS    
-    @heather = Applicant.create!(name: "Heather Moore", street: "Pearl St", city: "Denver", state: "CO", zip: "80210", good_home: "live close to dog parks")
-    @olivia = Applicant.create!(name: "Olivia Valentin", street: "1234 Main St", city: "Denver", state: "CO", zip: "80203", good_home: "I have vetenarian expierence")
-    
+    @heather = Applicant.create!(name: "Heather Moore", street: "Pearl St", city: "Denver", state: "CO", zip: "80210")
+    @olivia = Applicant.create!(name: "Olivia Valentin", street: "1234 Main St", city: "Denver", state: "CO", zip: "80203")
+    @thomas = Applicant.create!(name: "Thomas", street: "1515 15 Ave", city: "Denver", state: "CO", zip: "80203", good_home: "Lots of love and land!", status: "Pending")
+    PetApplicant.create!(applicant: @thomas, pet: @lobster)
     PetApplicant.create!(applicant: @olivia, pet: @lucille_bald)
     PetApplicant.create!(applicant: @olivia, pet: @lobster)

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -22,14 +22,13 @@ RSpec.describe "Admin Shelters Index" do
   describe 'shelters with pending applications' do
     it 'has section for the name of shelters with pending applications' do
       visit "/admin/shelters"
-      save_and_open_page
+
       expect(page).to have_content("Shelters with Pending Applications")
       
       within "#shelter-#{@mystery_bldg.id}" do
         expect(page).to have_content("#{@mystery_bldg.name}")
         expect(page).to_not have_content("#{@aurora.name}")
         expect(page).to_not have_content("#{@boulder.name}")
-        
       end
     end
   end

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -22,9 +22,15 @@ RSpec.describe "Admin Shelters Index" do
   describe 'shelters with pending applications' do
     it 'has section for the name of shelters with pending applications' do
       visit "/admin/shelters"
-
+      save_and_open_page
       expect(page).to have_content("Shelters with Pending Applications")
       
+      within "#shelter-#{@mystery_bldg.id}" do
+        expect(page).to have_content("#{@mystery_bldg.name}")
+        expect(page).to_not have_content("#{@aurora.name}")
+        expect(page).to_not have_content("#{@boulder.name}")
+        
+      end
     end
   end
 end


### PR DESCRIPTION
Create a pending applications section on the admin/shelters page. Only shows shelters that have pending applications. 

Write tests, and use a within to test the section of the page. GO TEAM!!